### PR TITLE
Add commit message linting with gitlint

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,21 @@
+---
+name: Linting
+
+on:
+  pull_request:
+
+jobs:
+  gitlint:
+    name: Commit Message(s)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@25a956c84d5dd820d28caab9f86b8d183aeeff3d
+        with:
+          fetch-depth: 0
+      - name: Run gitlint
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y golang gitlint
+          go version
+          make gitlint

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,9 @@
+[general]
+# body-is-missing: Allow commit messages with only a title
+# body-min-length: Allow short body lines, like "Relates-to: #issue"
+ignore=body-is-missing,body-min-length
+
+[ignore-by-body]
+# Dependabot doesn't follow our conventions, unfortunately
+regex=^Signed-off-by: dependabot\[bot\](.*)
+ignore=all

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BASE_BRANCH ?= main
 all: build
 .PHONY: all
 
@@ -58,6 +59,9 @@ clusters:
 
 demo:
 	scripts/demo.sh
+
+gitlint:
+	gitlint --commits origin/$(BASE_BRANCH)..HEAD
 
 update-csv: ensure-operator-sdk
 	cd deploy && rm -rf olm-catalog/manifests && ../$(OPERATOR_SDK) generate bundle --manifests --deploy-dir config/ --crds-dir config/crds/ --output-dir olm-catalog/ --version $(CSV_VERSION)


### PR DESCRIPTION
Lint git commit messages for best practices and to automatically enforce
common standards.

Uses GitHub Actions as the CI runner for now.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>